### PR TITLE
Issue with the URL useSerieDetails.ts

### DIFF
--- a/src/hooks/useSerieDetails.ts
+++ b/src/hooks/useSerieDetails.ts
@@ -18,7 +18,7 @@ export default function useSerieDetails (serieId: string | string[] | undefined)
     const getMovieDetails = async (id: string | string[]) => {
         if (typeof id === "string") {
             try {
-                const response = await axios.get(`https://api.themoviedb.org/3/movie/${serieId}`, {
+                const response = await axios.get(`https://api.themoviedb.org/3/tv/${serieId}`, {
                     params: {
                         api_key: process.env.NEXT_PUBLIC_API_KEY,
                         language: 'pt-BR'


### PR DESCRIPTION
- Issue with the URL that was getting the keys from movies instead of series.
- When I clicked on a series, a different ID was being pulled from the selected series, in this case a movie with the ID of the series was being pulled